### PR TITLE
Add ability to pass whole response object to NS1Error class

### DIFF
--- a/lib/NS1_request.js
+++ b/lib/NS1_request.js
@@ -191,13 +191,15 @@ function handle_error(err, response) {
     errorCb(err, response);
   }
   if (response && response.text) {
-    var final_message = void 0;
+    var final_message = void 0,
+        data = void 0;
     try {
-      final_message = JSON.parse(response.text).message;
+      data = JSON.parse(response.text);
+      final_message = data.message;
     } catch (e) {
       final_message = response.text;
     }
-    return new NS1Error('NS1 API Request Failed on \n ' + this.method.toUpperCase() + ' ' + api_url + this.uri + ' \n ' + final_message + ' \n', final_message);
+    return new NS1Error('NS1 API Request Failed on \n ' + this.method.toUpperCase() + ' ' + api_url + this.uri + ' \n ' + final_message + ' \n', final_message, data);
   } else {
     return new NS1Error('NS1 API Request Failed on \n ' + this.method.toUpperCase() + ' ' + api_url + this.uri + ' \n ' + err.message + ' \n', err.message);
   }
@@ -206,12 +208,13 @@ function handle_error(err, response) {
 var NS1Error = function (_Error) {
   _inherits(NS1Error, _Error);
 
-  function NS1Error(message, raw) {
+  function NS1Error(message, raw, data) {
     _classCallCheck(this, NS1Error);
 
     var _this3 = _possibleConstructorReturn(this, (NS1Error.__proto__ || Object.getPrototypeOf(NS1Error)).call(this, message));
 
     _this3.raw = raw;
+    _this3.data = data;
     return _this3;
   }
 

--- a/src/NS1_request.js
+++ b/src/NS1_request.js
@@ -161,22 +161,24 @@ function handle_error(err, response) {
     errorCb(err, response);
   }
   if (response && response.text) {
-    let final_message
+    let final_message, data
     try {
-      final_message = JSON.parse(response.text).message
+      data = JSON.parse(response.text)
+      final_message = data.message
     } catch(e) {
       final_message = response.text
     }
-    return new NS1Error(`NS1 API Request Failed on \n ${this.method.toUpperCase()} ${api_url}${this.uri} \n ${final_message} \n`, final_message)
+    return new NS1Error(`NS1 API Request Failed on \n ${this.method.toUpperCase()} ${api_url}${this.uri} \n ${final_message} \n`, final_message, data)
   } else {
     return new NS1Error(`NS1 API Request Failed on \n ${this.method.toUpperCase()} ${api_url}${this.uri} \n ${err.message} \n`, err.message)
   }
 }
 
 class NS1Error extends Error {
-  constructor(message, raw) {
+  constructor(message, raw, data) {
     super(message)
     this.raw = raw
+    this.data = data
   }
 }
 


### PR DESCRIPTION
In the presence of a new error structure coming from backend, we need to have the ability to pass the response object as a part of the NS1Error to be able to handle old and new structures simultaneously.